### PR TITLE
Added 2FA using OTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/.vscode
 Cargo.lock
 webeep.iml
 .idea

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,6 @@ fn main() {
         print!("Password: ");
         std::io::stdout().flush().unwrap();
         stdin().read_line(&mut pass).unwrap();
-        print!("OTP: ");
-        std::io::stdout().flush().unwrap();
-        stdin().read_line(&mut otp).unwrap();
         print!("\x1B[2J\x1B[1;1H");
         let my_cfg = User {id: id.clone(), pass: pass.clone()};
         confy::store("webeep",my_cfg).expect("Error in creating the config file!");
@@ -47,9 +44,6 @@ fn main() {
         print!("Password: ");
         std::io::stdout().flush().unwrap();
         stdin().read_line(&mut pass).unwrap();
-        print!("OTP: ");
-        std::io::stdout().flush().unwrap();
-        stdin().read_line(&mut otp).unwrap();
         print!("\x1B[2J\x1B[1;1H");
         let my_cfg = User {id: id.clone(), pass: pass.clone()};
         confy::store("webeep",my_cfg).expect("Error in creating the config file!");
@@ -57,10 +51,11 @@ fn main() {
     else {
         id = cfg.id;
         pass = cfg.pass;
-        print!("OTP: ");
-        std::io::stdout().flush().unwrap();
-        stdin().read_line(&mut otp).unwrap();
     }
+
+    print!("OTP: ");
+    std::io::stdout().flush().unwrap();
+    stdin().read_line(&mut otp).unwrap();
     let mut controller = controller::Controller::new(id.trim(),pass.trim(),otp.trim());
     controller.start();
     let mut usr_input = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,8 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     let mut id = String::from("");
     let mut pass = String::from("");
+    let mut otp = String::from("");
+
     if args.len() > 1 && args[1].eq("--login") {
         print!("PoliMi id: ");
         std::io::stdout().flush().unwrap();
@@ -28,11 +30,15 @@ fn main() {
         print!("Password: ");
         std::io::stdout().flush().unwrap();
         stdin().read_line(&mut pass).unwrap();
+        print!("OTP: ");
+        std::io::stdout().flush().unwrap();
+        stdin().read_line(&mut otp).unwrap();
         print!("\x1B[2J\x1B[1;1H");
         let my_cfg = User {id: id.clone(), pass: pass.clone()};
         confy::store("webeep",my_cfg).expect("Error in creating the config file!");
     }
     let cfg : User = confy::load("webeep").expect("Error in reading the config file!");
+
     if cfg.id.eq("") {
         println!("You only have to enter your credentials on the first launch!");
         print!("PoliMi id: ");
@@ -41,6 +47,9 @@ fn main() {
         print!("Password: ");
         std::io::stdout().flush().unwrap();
         stdin().read_line(&mut pass).unwrap();
+        print!("OTP: ");
+        std::io::stdout().flush().unwrap();
+        stdin().read_line(&mut otp).unwrap();
         print!("\x1B[2J\x1B[1;1H");
         let my_cfg = User {id: id.clone(), pass: pass.clone()};
         confy::store("webeep",my_cfg).expect("Error in creating the config file!");
@@ -48,8 +57,11 @@ fn main() {
     else {
         id = cfg.id;
         pass = cfg.pass;
+        print!("OTP: ");
+        std::io::stdout().flush().unwrap();
+        stdin().read_line(&mut otp).unwrap();
     }
-    let mut controller = controller::Controller::new(id.trim(),pass.trim());
+    let mut controller = controller::Controller::new(id.trim(),pass.trim(),otp.trim());
     controller.start();
     let mut usr_input = String::new();
     let mut curr_pos = Vec::new();

--- a/src/utils/html_parser.rs
+++ b/src/utils/html_parser.rs
@@ -6,7 +6,7 @@ pub fn get_courses_keys(html : String) -> Vec<String>{
     let ul_selector = Selector::parse("ul").unwrap();
     let li_selector = Selector::parse("li").unwrap();
 
-    let ul = fragment.select(&ul_selector).skip(5).next().unwrap();
+    let ul = fragment.select(&ul_selector).skip(6).next().unwrap();
     for element in ul.select(&li_selector) {
         keys.push( String::from(element.value().attr("data-key").unwrap()));
     }

--- a/src/utils/http_client.rs
+++ b/src/utils/http_client.rs
@@ -19,8 +19,16 @@ impl HttpClient {
 
     pub fn get_action_from_html(&mut self,response : Response) -> String{
         let html = response.text().expect("Error while parsing the html!");
+        let start_index = html.find(" action=").expect("Error while parsing the html! Could not find starting index.") + 9;
+        let end_index = html.find("\" class=\"jaf-form jaf-mobile-form\"><button").expect("Error while parsing the html! Could not find ending index.");
+        let action = &html[start_index..end_index];
+        return String::from(action);
+    }
+
+    pub fn get_action_from_html_otp(&mut self,response : Response) -> String{
+        let html = response.text().expect("Error while parsing the html!");
         let start_index = html.find(" action=").expect("Error while parsing the html!") + 9;
-        let end_index = html.find("\" class=\"jaf-form jaf-mobile-form\"><button").expect("Error while parsing the html!");
+        let end_index = html.find("\" id=\"form_scelta2fa\" class=\"jaf-form jaf-mobile-form\"><button").expect("Error while parsing the html!");
         let action = &html[start_index..end_index];
         return String::from(action);
     }
@@ -45,6 +53,12 @@ impl HttpClient {
     pub fn hidden_post_req(&mut self, url : String, first_param : String, second_param : String) -> Response {
         let params = [("RelayState", first_param.as_str()),("SAMLResponse",second_param.as_str())];
         let res = self.client.post(url).form(&params).send().expect("Failed to execute hidden post request");
+        return res;
+    }
+
+    pub fn otp_post_req(&mut self, url: String, otp_key: &str) -> Response {
+        let params = [("evn_continua",""),("otp", otp_key)];
+        let res = self.client.post(url).form(&params).send().expect("Failed to execute OTP post request");
         return res;
     }
 }


### PR DESCRIPTION
The only way to login by skipping SpID authentication is by enabling TOTP from within the online services settings. This fix allows the WeBeeP-cli to login using OTP and makes the program usable again.